### PR TITLE
make a typo

### DIFF
--- a/zh/6-advanced_patterns_for_views_and_routing.md
+++ b/zh/6-advanced_patterns_for_views_and_routing.md
@@ -140,7 +140,7 @@ r2 = two()
 r1 == r2 # True
 ```
 
-下面这个例子用到了我们自定义的装饰器和来自Flask-Cache拓展的`@login_required`装饰器。我们可以将多个装饰器堆成栈来一起使用。
+下面这个例子用到了我们自定义的装饰器和来自Flask-login拓展的`@login_required`装饰器。我们可以将多个装饰器堆成栈来一起使用。
 
 myapp/views.py
 ```


### PR DESCRIPTION
> 下面这个例子用到了我们自定义的装饰器和来自Flask-Cache拓展的`@login_required`装饰器。我们可以将多个装饰器堆成栈来一起使用。

`Flask-Cache` 改成 `Flask-login`